### PR TITLE
Update hero bio copy and balance portrait layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,14 +36,15 @@
             <p class="subheadline">
               Ph.D. Candidate in Electrical Engineering at the Network &amp; System Security (NSS) Lab, KAIST<br />
               Daejeon, South Korea <br />
-              Advisor: Prof. Seungwon Shin
+              Advisor: <a href="https://nss.kaist.ac.kr/?page_id=29" target="_blank" rel="noreferrer">Prof. Seungwon Shin</a>
             </p>
             <p>
-              I am a researcher focusing on the safety and security of large language models and data-driven security systems. My work spans
-              <strong>model safety (unlearning, backdoors, and safety routing in Mixture-of-Experts models)</strong>,
-              <strong>AI for security</strong>, and
-              <strong>graph-based analysis for credential abuse</strong>.
-              I aim to design scalable, empirically grounded methods that bridge academic rigor with real-world deployment.
+              I am a researcher specializing in the safety and security of large language models (LLMs) and data-driven security systems. My
+              research explores vulnerabilities and defense mechanisms in emerging AI paradigms such as unlearning, agentic systems,
+              parameter-efficient fine-tuning (PEFT), and mixture-of-experts (MoE) architectures, while also leveraging AI to address security
+              challenges including illicit drug detection and credential stuffing risk prediction. By combining rigorous empirical analysis with
+              a focus on real-world applicability, I aim to design scalable methods that bridge academic research and practical deployment,
+              ensuring that AI-driven systems operate in a safe and secure manner.
             </p>
             <div class="cta-group" role="group" aria-label="Contact links">
               <a class="chip" href="mailto:minkyoo9@kaist.ac.kr" aria-label="Send an email to Minkyoo Song">
@@ -55,23 +56,29 @@
               <a class="chip" href="https://www.linkedin.com/in/minkyoo-song-366aa7348/" target="_blank" rel="noreferrer">
                 <span class="icon">in</span> LinkedIn
               </a>
-              <a class="chip" href="https://nss.kaist.ac.kr/?page_id=29" target="_blank" rel="noreferrer">
+              <a class="chip" href="https://nss.kaist.ac.kr/" target="_blank" rel="noreferrer">
                 <span class="icon">🎓</span> NSS Lab
               </a>
             </div>
-            <p class="meta">Last updated: June 2025</p>
+            <p class="meta">Last updated: September 2025</p>
           </div>
-          <aside class="card interests" aria-labelledby="research-interests">
-            <h2 class="card-title" id="research-interests">
-              <span class="icon">⚖️</span> Research Interests
-            </h2>
-            <ul>
-              <li>LLM Security</li>
-              <li>AI for Security</li>
-              <li>Data-driven Security</li>
-              <li>Social Network Analysis</li>
-            </ul>
-          </aside>
+          <div class="hero-aside">
+            <figure class="hero-portrait" aria-labelledby="hero-portrait-caption">
+              <img src="assets/minkyoo-song.png" alt="Portrait of Minkyoo Song" loading="lazy" />
+              <figcaption id="hero-portrait-caption" class="visually-hidden">Portrait of Minkyoo Song</figcaption>
+            </figure>
+            <aside class="card interests" aria-labelledby="research-interests">
+              <h2 class="card-title" id="research-interests">
+                <span class="icon">⚖️</span> Research Interests
+              </h2>
+              <ul>
+                <li>LLM Security</li>
+                <li>AI for Security</li>
+                <li>Data-driven Security</li>
+                <li>Social Network Analysis</li>
+              </ul>
+            </aside>
+          </div>
         </div>
       </section>
 
@@ -79,93 +86,142 @@
         <div class="section-header">
           <h2 class="section-title">
             <span class="icon">📰</span>
-            <span id="publications-heading">Selected Publications</span>
+            <span id="publications-heading">Publications</span>
           </h2>
-          <p class="section-subtitle">Peer-reviewed works and manuscripts under review.</p>
         </div>
 
-        <div class="publication-group">
-          <h3>Conference Publications</h3>
-          <ul class="card-list">
-            <li>
-              <p class="authors">J. Kim, S.H. Na, M. Song, S. Shin, S. Son</p>
-              <p class="title">MoEvil: Poisoning Expert to Compromise the Safety of Mixture-of-Experts LLMs</p>
-              <p class="venue">ACSAC 2025</p>
-            </li>
-            <li>
-              <p class="authors">M. Song, H. Kim, J. Kim, S. Shin, S. Son</p>
-              <p class="title">Refusal Is Not an Option: Unlearning Safety Alignment of Large Language Models</p>
-              <p class="venue">USENIX Security 2025 · <a href="https://www.usenix.org/conference/usenixsecurity25/presentation/song-minkyoo" target="_blank" rel="noreferrer">USENIX</a></p>
-            </li>
-            <li>
-              <p class="authors">H. Kim, M. Song, S.H. Na, S. Shin, K. Lee</p>
-              <p class="title">When LLMs Go Online: The Emerging Threat of Web-Enabled LLMs</p>
-              <p class="venue">USENIX Security 2025 · <a href="https://www.usenix.org/conference/usenixsecurity25/presentation/kim-hanna" target="_blank" rel="noreferrer">USENIX</a></p>
-            </li>
-            <li>
-              <p class="authors">M. Song, H. Kim, J. Kim, Y. Jin, S. Shin</p>
-              <p class="title">Claim-Guided Textual Backdoor Attack for Practical Applications</p>
-              <p class="venue">NAACL 2025 Findings · <a href="https://aclanthology.org/2025.findings-naacl.64/" target="_blank" rel="noreferrer">ACL Anthology</a></p>
-            </li>
-            <li>
-              <p class="authors">J. Kim, M. Song, S.H. Na, S. Shin</p>
-              <p class="title">Obliviate: Neutralizing Task-Agnostic Backdoors within the Parameter-Efficient Fine-Tuning Paradigm</p>
-              <p class="venue">NAACL 2025 Findings · <a href="https://aclanthology.org/2025.findings-naacl.71/" target="_blank" rel="noreferrer">ACL Anthology</a></p>
-            </li>
-            <li>
-              <p class="authors">M. Song, E. Jang, J. Kim, S. Shin</p>
-              <p class="title">Covering Cracks in Content Moderation: Delexicalized Distant Supervision for Illicit Drug Jargon Detection</p>
-              <p class="venue">KDD 2025 · <a href="https://dl.acm.org/doi/10.1145/3690624.3709183" target="_blank" rel="noreferrer">ACM DL</a></p>
-            </li>
-            <li>
-              <p class="authors">J. Kim, M. Song, M. Seo, Y. Jin, S. Shin</p>
-              <p class="title">PassREfinder: Credential Stuffing Risk Prediction by Representing Password Reuse between Websites on a Graph</p>
-              <p class="venue">IEEE Symposium on Security and Privacy 2024 · <a href="https://ieeexplore.ieee.org/document/10646687?reason=concurrency" target="_blank" rel="noreferrer">IEEE Xplore</a></p>
-            </li>
-          </ul>
-        </div>
-
-        <div class="publication-group">
-          <h3>Journal Publications</h3>
-          <ul class="card-list">
-            <li>
-              <p class="authors">J. Choi, J. Kim, M. Song, H. Kim, N. Park, M. Seo, Y. Jin, S. Shin</p>
-              <p class="title">A Large-Scale Bitcoin Abuse Measurement and Clustering Analysis Utilizing Public Reports</p>
-              <p class="venue">IEICE Transactions on Information and Systems, 2022 · <a href="https://globals.ieice.org/en_transactions/information/10.1587/transinf.2021EDP7182/_p" target="_blank" rel="noreferrer">IEICE</a></p>
-            </li>
-          </ul>
-        </div>
-
-        <div class="publication-group">
-          <h3>Manuscripts Under Review</h3>
-          <ul class="card-list">
-            <li>
-              <p class="authors">J. Kim, M. Song, M. Seo, Y. Jin, S. Shin, J. Kim</p>
-              <p class="title">PassREfinder-FL: Privacy-Preserving Credential Stuffing Risk Prediction via Graph-Based Federated Learning for Representing Password Reuse between Websites</p>
-              <p class="venue">Expert Systems with Applications (major revision)</p>
-            </li>
-            <li>
-              <p class="authors">K. Kim, J. Cui, M. Song, S. Shin</p>
-              <p class="title">Exploring the Familiar Taste of Toxicity: A Causal Influence Analysis of Toxic Comments on Internet Forums</p>
-              <p class="venue">IEEE Transactions on Knowledge and Data Engineering (major revision)</p>
-            </li>
-            <li>
-              <p class="authors">J. Kim, M. Song, S. Shin, S. Son</p>
-              <p class="title">SAFEMOE: Safe Fine-Tuning for MoE LLMs by Aligning Harmful Input Routing</p>
-              <p class="venue">International Conference on Learning Representations 2026 (under review)</p>
-            </li>
-            <li>
-              <p class="authors">K. Kim, S.H. Na, M. Song, S. Shin</p>
-              <p class="title">Global Meta-path-level Counterfactual Explanation for Heterogeneous Graph Neural Networks by Path Exclusion</p>
-              <p class="venue">International Conference on Learning Representations 2026 (under review)</p>
-            </li>
-            <li>
-              <p class="authors">J. Kim, M. Seo, M. Song, S. Shin, J. Kim</p>
-              <p class="title">To Make Each Account Count: Exploring Credential Data Breach Threats through Victim-driven Analysis</p>
-              <p class="venue">IEEE Transactions on Information Forensics and Security (under review)</p>
-            </li>
-          </ul>
-        </div>
+        <ol class="pub-list">
+          <li>
+            <span class="pub-label">[C]</span>
+            <div class="pub-entry">
+              <p class="pub-authors">J. Kim, S.H. Na, <span class="highlight">M. Song</span>, S. Shin, S. Son.</p>
+              <p class="pub-title">
+                <a href="https://scholar.google.com/citations?user=PCK7c-MAAAAJ&amp;hl=en" target="_blank" rel="noreferrer"><strong>MoEvil: Poisoning Expert to Compromise the Safety of Mixture-of-Experts LLMs</strong></a>.
+              </p>
+              <p class="pub-venue"><em>2025 Annual Computer Security Applications Conference (<strong>ACSAC 2025</strong>)</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[C]</span>
+            <div class="pub-entry">
+              <p class="pub-authors"><span class="highlight">M. Song</span>, H. Kim, J. Kim, S. Shin, S. Son.</p>
+              <p class="pub-title">
+                <a href="https://www.usenix.org/conference/usenixsecurity25/presentation/song-minkyoo" target="_blank" rel="noreferrer"><strong>Refusal Is Not an Option: Unlearning Safety Alignment of Large Language Models</strong></a>.
+              </p>
+              <p class="pub-venue"><em>34th USENIX Security Symposium (<strong>USENIX Sec 2025</strong>)</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[C]</span>
+            <div class="pub-entry">
+              <p class="pub-authors">H. Kim, <span class="highlight">M. Song</span>, S.H. Na, S. Shin, K. Lee.</p>
+              <p class="pub-title">
+                <a href="https://www.usenix.org/conference/usenixsecurity25/presentation/kim-hanna" target="_blank" rel="noreferrer"><strong>When LLMs Go Online: The Emerging Threat of Web-Enabled LLMs</strong></a>.
+              </p>
+              <p class="pub-venue"><em>34th USENIX Security Symposium (<strong>USENIX Sec 2025</strong>)</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[C]</span>
+            <div class="pub-entry">
+              <p class="pub-authors"><span class="highlight">M. Song</span>, H. Kim, J. Kim, Y. Jin, S. Shin.</p>
+              <p class="pub-title">
+                <a href="https://aclanthology.org/2025.findings-naacl.64/" target="_blank" rel="noreferrer"><strong>Claim-Guided Textual Backdoor Attack for Practical Applications</strong></a>.
+              </p>
+              <p class="pub-venue"><em>The 2025 Annual Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics (<strong>NACCL 2025 Findings</strong>)</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[C]</span>
+            <div class="pub-entry">
+              <p class="pub-authors">J. Kim, <span class="highlight">M. Song</span>, S.H. Na, S. Shin.</p>
+              <p class="pub-title">
+                <a href="https://aclanthology.org/2025.findings-naacl.71/" target="_blank" rel="noreferrer"><strong>Obliviate: Neutralizing Task-Agnostic Backdoors within the Parameter-Efficient Fine-Tuning Paradigm</strong></a>.
+              </p>
+              <p class="pub-venue"><em>The 2025 Annual Conference of the Nations of the Americas Chapter of the Association for Computational Linguistics (<strong>NACCL 2025 Findings</strong>)</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[C]</span>
+            <div class="pub-entry">
+              <p class="pub-authors"><span class="highlight">M. Song</span>, E. Jang, J. Kim, S. Shin.</p>
+              <p class="pub-title">
+                <a href="https://dl.acm.org/doi/10.1145/3690624.3709183" target="_blank" rel="noreferrer"><strong>Covering Cracks in Content Moderation: Delexicalized Distant Supervision for Illicit Drug Jargon Detection</strong></a>.
+              </p>
+              <p class="pub-venue"><em>31st ACM SIGKDD Conference on Knowledge Discovery and Data Mining (<strong>KDD 2025</strong>)</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[C]</span>
+            <div class="pub-entry">
+              <p class="pub-authors">J. Kim, <span class="highlight">M. Song</span>, M. Seo, Y. Jin, S. Shin.</p>
+              <p class="pub-title">
+                <a href="https://ieeexplore.ieee.org/document/10646687?reason=concurrency" target="_blank" rel="noreferrer"><strong>PassREfinder: Credential Stuffing Risk Prediction by Representing Password Reuse between Websites on a Graph</strong></a>.
+              </p>
+              <p class="pub-venue"><em>2024 IEEE Symposium on Security and Privacy (SP) (<strong>S&amp;P 2024</strong>)</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[J]</span>
+            <div class="pub-entry">
+              <p class="pub-authors">J. Choi, J. Kim, <span class="highlight">M. Song</span>, H. Kim, N. Park, M. Seo, Y. Jin, S. Shin.</p>
+              <p class="pub-title">
+                <a href="https://globals.ieice.org/en_transactions/information/10.1587/transinf.2021EDP7182/_p" target="_blank" rel="noreferrer"><strong>A Large-Scale Bitcoin Abuse Measurement and Clustering Analysis Utilizing Public Reports</strong></a>.
+              </p>
+              <p class="pub-venue"><em>2022 IEICE Transactions on Information and Systems</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[U]</span>
+            <div class="pub-entry">
+              <p class="pub-authors">J. Kim, <span class="highlight">M. Song</span>, M. Seo, Y. Jin, S. Shin, J. Kim.</p>
+              <p class="pub-title">
+                <a href="https://scholar.google.com/citations?user=PCK7c-MAAAAJ&amp;hl=en" target="_blank" rel="noreferrer"><strong>PassREfinder-FL: Privacy-Preserving Credential Stuffing Risk Prediction via Graph-Based Federated Learning for Representing Password Reuse between Websites</strong></a>.
+              </p>
+              <p class="pub-venue"><em>Invited to Major Revision at Elsevier Expert Systems with Applications (ESWA)</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[U]</span>
+            <div class="pub-entry">
+              <p class="pub-authors">K. Kim, J. Cui, <span class="highlight">M. Song</span>, S. Shin.</p>
+              <p class="pub-title">
+                <a href="https://scholar.google.com/citations?user=PCK7c-MAAAAJ&amp;hl=en" target="_blank" rel="noreferrer"><strong>Exploring the Familiar Taste of Toxicity: A Causal Influence Analysis of Toxic Comments on Internet Forums</strong></a>.
+              </p>
+              <p class="pub-venue"><em>Invited to Major Revision at IEEE Transactions on Knowledge and Data Engineering (TKDE)</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[U]</span>
+            <div class="pub-entry">
+              <p class="pub-authors">J. Kim, <span class="highlight">M. Song</span>, S. Shin, S. Son.</p>
+              <p class="pub-title">
+                <a href="https://scholar.google.com/citations?user=PCK7c-MAAAAJ&amp;hl=en" target="_blank" rel="noreferrer"><strong>SAFEMOE: Safe Fine-Tuning for MoE LLMs by Aligning Harmful Input Routing</strong></a>.
+              </p>
+              <p class="pub-venue"><em>Submitted to International Conference on Learning Representations (ICLR) 2026</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[U]</span>
+            <div class="pub-entry">
+              <p class="pub-authors">K. Kim, S.H. Na, <span class="highlight">M. Song</span>, S. Shin.</p>
+              <p class="pub-title">
+                <a href="https://scholar.google.com/citations?user=PCK7c-MAAAAJ&amp;hl=en" target="_blank" rel="noreferrer"><strong>Global Meta-path-level Counterfactual Explanation for Heterogeneous Graph Neural Networks by Path Exclusion</strong></a>.
+              </p>
+              <p class="pub-venue"><em>Submitted to International Conference on Learning Representations (ICLR) 2026</em></p>
+            </div>
+          </li>
+          <li>
+            <span class="pub-label">[U]</span>
+            <div class="pub-entry">
+              <p class="pub-authors">J. Kim, M. Seo, <span class="highlight">M. Song</span>, S. Shin, J. Kim.</p>
+              <p class="pub-title">
+                <a href="https://scholar.google.com/citations?user=PCK7c-MAAAAJ&amp;hl=en" target="_blank" rel="noreferrer"><strong>To Make Each Account Count: Exploring Credential Data Breach Threats through Victim-driven Analysis</strong></a>.
+              </p>
+              <p class="pub-venue"><em>Submitted to IEEE Transactions on Information Forensics and Security (TIFS)</em></p>
+            </div>
+          </li>
+        </ol>
       </section>
 
       <section class="section" id="experience" aria-labelledby="experience-heading">
@@ -305,10 +361,10 @@
         <div class="card contact-card">
           <p>For collaborations or inquiries, please use the channels below.</p>
           <div class="cta-group">
-            <a class="chip" href="mailto:minkyoo9@kaist.ac.kr"><span class="icon">@</span> Email</a>
+            <a class="chip" href="mailto:minkyoo9@kaist.ac.kr" aria-label="Send an email to Minkyoo Song"><span class="icon">@</span> Email</a>
             <a class="chip" href="https://www.linkedin.com/in/minkyoo-song-366aa7348/" target="_blank" rel="noreferrer"><span class="icon">in</span> LinkedIn</a>
             <a class="chip" href="https://scholar.google.com/citations?user=PCK7c-MAAAAJ&amp;hl=en" target="_blank" rel="noreferrer"><span class="icon">📚</span> Google Scholar</a>
-            <a class="chip" href="https://nss.kaist.ac.kr/?page_id=29" target="_blank" rel="noreferrer"><span class="icon">🎓</span> NSS Lab</a>
+            <a class="chip" href="https://nss.kaist.ac.kr/" target="_blank" rel="noreferrer"><span class="icon">🎓</span> NSS Lab</a>
           </div>
         </div>
       </section>

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,18 @@ body {
   line-height: 1.6;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 img {
   max-width: 100%;
   display: block;
@@ -114,6 +126,44 @@ main {
 .hero-content {
   display: grid;
   gap: 2rem;
+  align-items: stretch;
+}
+
+.hero-aside {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: stretch;
+  justify-content: space-between;
+}
+
+.hero-portrait {
+  margin: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  width: clamp(160px, 28vw, 220px);
+  align-self: center;
+  flex-shrink: 0;
+}
+
+.hero-portrait img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
+.card.interests {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card.interests ul {
+  margin: 0;
+  padding-left: 1.1rem;
 }
 
 .hero-copy {
@@ -232,41 +282,69 @@ main {
   margin-bottom: 0.25rem;
 }
 
-.publication-group {
-  margin-bottom: 2.5rem;
+.pub-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1.5rem;
 }
 
-.publication-group h3 {
-  margin-bottom: 1rem;
-  font-size: 1.25rem;
-  font-weight: 600;
+.pub-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
 }
 
-.publication-group .title {
-  margin: 0.25rem 0 0.5rem;
-  font-weight: 600;
-  font-style: italic;
+.pub-label {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--accent);
+  min-width: 2.75rem;
 }
 
-.publication-group .authors {
+.pub-entry {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.pub-authors {
   margin: 0;
   color: var(--muted);
   font-size: 0.95rem;
 }
 
-.publication-group .venue {
+.pub-title {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: 1.05rem;
 }
 
-.publication-group a {
-  color: var(--accent);
+.pub-title a {
+  color: inherit;
   text-decoration: none;
 }
 
-.publication-group a:hover,
-.publication-group a:focus {
+.pub-title a:hover,
+.pub-title a:focus {
   text-decoration: underline;
+}
+
+.pub-venue {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.highlight {
+  background: var(--accent-soft);
+  padding: 0 0.25rem;
+  border-radius: 0.25rem;
 }
 
 .grid-list {
@@ -307,7 +385,6 @@ main {
 @media (min-width: 768px) {
   .hero-content {
     grid-template-columns: 2fr 1fr;
-    align-items: flex-start;
   }
 
   .card-header {


### PR DESCRIPTION
## Summary
- replace the hero biography paragraph with the updated description covering LLM safety and security research
- shrink the portrait and adjust the hero aside layout so the image and research interests column balances with the main bio card

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dce0edb0a08320a1cb0535c16a07bd