### PR TITLE
Refine CV template for a more formal, academic look

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Curriculum Vitae of Minkyoo Song, Ph.D. candidate in Electrical Engineering at KAIST." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,12 @@
 :root {
   color-scheme: light;
-  --bg: #f5f5f5;
+  --bg: #f9f8f6;
   --surface: #ffffff;
-  --border: #e2e2e2;
-  --text: #1f1f1f;
-  --muted: #5f5f5f;
-  --accent: #1d4ed8;
-  --accent-soft: #e0e7ff;
+  --border: #d6d3d1;
+  --text: #1f2933;
+  --muted: #4b5563;
+  --accent: #0f172a;
+  --accent-soft: #f1f5f9;
   font-size: 16px;
 }
 
@@ -16,7 +16,7 @@
 
 body {
   margin: 0;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: 'Source Serif 4', 'Times New Roman', serif;
   background: var(--bg);
   color: var(--text);
   line-height: 1.6;
@@ -54,8 +54,7 @@ img {
   position: sticky;
   top: 0;
   z-index: 100;
-  backdrop-filter: blur(8px);
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.97);
   border-bottom: 1px solid var(--border);
 }
 
@@ -68,6 +67,7 @@ img {
 }
 
 .brand {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-weight: 600;
   text-decoration: none;
   color: inherit;
@@ -78,6 +78,7 @@ img {
   display: flex;
   gap: 1.5rem;
   font-size: 0.9375rem;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .site-nav a {
@@ -112,6 +113,7 @@ main {
   font-size: 1.75rem;
   font-weight: 600;
   letter-spacing: -0.01em;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .section-subtitle {
@@ -141,8 +143,7 @@ main {
   margin: 0;
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 24px;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border-radius: 12px;
   overflow: hidden;
   max-width: 320px;        
   width: 100%;            
@@ -179,9 +180,8 @@ main {
 .hero-copy {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 24px;
+  border-radius: 12px;
   padding: 2rem;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
 }
 
 .headline {
@@ -189,12 +189,14 @@ main {
   font-size: clamp(2.25rem, 4vw, 3rem);
   font-weight: 700;
   letter-spacing: -0.02em;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .subheadline {
   margin: 0 0 1.5rem;
   color: var(--muted);
   font-size: 1.05rem;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .hero-copy p {
@@ -205,6 +207,7 @@ main {
   color: var(--muted);
   font-size: 0.9rem;
   margin-top: 1.5rem;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .cta-group {
@@ -219,20 +222,19 @@ main {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  border-radius: 999px;
+  border-radius: 6px;
   border: 1px solid var(--border);
   background: var(--surface);
   color: inherit;
   text-decoration: none;
   font-weight: 500;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  transition: border-color 0.2s ease;
 }
 
 .chip:hover,
 .chip:focus {
   border-color: var(--accent);
-  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.15);
-  transform: translateY(-1px);
 }
 
 .icon {
@@ -242,13 +244,17 @@ main {
   justify-content: center;
 }
 
+.section-title .icon,
+.card-title .icon {
+  display: none;
+}
+
 .card,
 .card-list li {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 20px;
+  border-radius: 12px;
   padding: 1.5rem;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
 }
 
 .card-list {
@@ -263,12 +269,14 @@ main {
   margin: 0;
   font-weight: 600;
   font-size: 1.05rem;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .card-meta {
   margin: 0.35rem 0 0;
   color: var(--muted);
   font-size: 0.9rem;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .card-description {
@@ -307,9 +315,8 @@ main {
   align-items: start;
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 20px;
+  border-radius: 12px;
   padding: 1.5rem;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
 }
 
 .pub-label {
@@ -317,6 +324,7 @@ main {
   font-size: 1.05rem;
   color: var(--accent);
   min-width: 2.75rem;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .pub-entry {
@@ -328,11 +336,13 @@ main {
   margin: 0;
   color: var(--muted);
   font-size: 0.95rem;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .pub-title {
   margin: 0;
   font-size: 1.05rem;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .pub-title a {
@@ -349,12 +359,13 @@ main {
   margin: 0;
   font-size: 0.9rem;
   color: var(--muted);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .highlight {
   background: var(--accent-soft);
-  padding: 0 0.25rem;
-  border-radius: 0.25rem;
+  padding: 0 0.2rem;
+  border-radius: 0.2rem;
 }
 
 .grid-list {
@@ -368,9 +379,8 @@ main {
 .grid-list li {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 20px;
+  border-radius: 12px;
   padding: 1.5rem;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
 }
 
 .card-list.two-column {
@@ -390,6 +400,7 @@ main {
   text-align: center;
   color: var(--muted);
   font-size: 0.9rem;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
### Motivation
- Make the existing CV template feel more formal and academic while preserving the current content and structure.
- Shift visual tone via typography, color, and subtle layout refinements to improve readability and professional presence.

### Description
- Add a serif/sans-serif font pairing by loading `Source Serif 4` alongside `Inter` and set `body` to use `Source Serif 4` while keeping `Inter` for headings and UI elements in `index.html` and `styles.css`.
- Update the color variables in `:root` (`--bg`, `--border`, `--text`, `--muted`, `--accent`, `--accent-soft`) to a subdued, academic palette and tune header background alpha for a cleaner look.
- Reduce decorative styling by lowering corner radii (24/20px → 12px), removing heavy box-shadows, simplifying chip styles (rounded pill → small rectangle) and reducing hover ornamentation.
- Hide small decorative icons in section and card headings and refine typographic usage across `.headline`, `.subheadline`, `.section-title`, `.card-title`, and publication elements for consistent hierarchy.

### Testing
- Launched a local static server with `python -m http.server 8000` to serve the site, which started successfully.
- Ran a Playwright script to open `http://127.0.0.1:8000/` and capture a full-page screenshot saved as `artifacts/formal-cv.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5d3128cc8320bfba975b6bc0b06a)